### PR TITLE
chore: declare yurtle-kanban v1.10.0 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Python tools used by noesis-ship agents
+yurtle-kanban @ git+https://github.com/hankh95/yurtle-kanban.git@v1.10.0


### PR DESCRIPTION
## Summary
- Add root `requirements.txt` declaring yurtle-kanban v1.10.0
- Previously undeclared — installed manually on each machine
- v1.10.0 includes: fail-closed rule evaluation, resolution/superseded_by fields, --force audit trail
- Part of EXP-913 consumer propagation

## Test plan
- [ ] `pip install -r requirements.txt` succeeds
- [ ] `yurtle-kanban board` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)