### PR TITLE
docs: link Related Projects to congruentsys.com + current NuSy stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,12 @@ Ships come in different sizes:
 
 ## Related Projects
 
-- **Ships Comm** (iOS) — Voice-first agent communication app (connects to noesis-ship via WebSocket)
-- **yurtle-kanban** — Pluggable kanban board for agent work tracking
-- **nusy-product-team** — AI beings platform (uses noesis-ship for communication)
+Part of the **NuSy** neurosymbolic AI platform by [Congruent Systems](https://congruentsys.com)
+— *software that reasons, not software that guesses.* See the [research](https://congruentsys.com/research/).
+
+- **[nusy-reasoners](https://github.com/Congruentsys/nusy-reasoners)** — proof-carrying reasoning over Apache Arrow; the symbolic core NuSy beings reason with (MIT).
+- **[nusy-kanban](https://crates.io/crates/nusy-kanban)** — Arrow-native, distributed kanban for multi-agent teams; coordinates the fleet over noesis-ship.
+- **Ships Comm** (iOS) — voice-first agent communication app (connects via WebSocket).
 
 ## License
 


### PR DESCRIPTION
**Part of the UAI-readiness pass (nk EX-5429).** Points noesis-ship's Related
Projects at the current NuSy stack (nusy-reasoners, nusy-kanban) and
congruentsys.com/research, so a reader (incl. a technical evaluator) can find the
platform it belongs to. Previously listed only the superseded yurtle-kanban with
no site link.

Docs-only, README Related Projects section. Reviewer ≠ author (not self-merged).

⚠ **NOT addressed here (flagged for a maintainer/legal decision, not silently changed):**
- README says License **ISC**, but the `LICENSE` file is **MIT** — a real inconsistency (LICENSE is authoritative → README is likely the stale one).
- `LICENSE` says "Congruent Systems **LLC**"; README Author says "Congruent Systems **PBC**" — entity-name mismatch.
Both are legal-identity calls for the maintainer to resolve; surfaced for the UAI data room.