### PR TITLE
chore(legal): Congruent Systems LLC + license metadata MIT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,8 +404,8 @@ This is a platform/library project. Contributions should:
 
 ## License
 
-ISC
+MIT — see [LICENSE](LICENSE).
 
 ## Author
 
-Congruent Systems PBC
+Congruent Systems LLC

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Part of the **NuSy** neurosymbolic AI platform by [Congruent Systems](https://co
 
 ## License
 
-ISC
+MIT — see [LICENSE](LICENSE).
 
 ## Author
 
-Congruent Systems PBC
+Congruent Systems LLC

--- a/docs/architecture-review-dgx.md
+++ b/docs/architecture-review-dgx.md
@@ -531,9 +531,9 @@ Each machine is autonomous. No central coordination required.
 | **Persistence** | JetStream (30-day history) | Unknown |
 | **Adapters** | WebSocket, MCP, HTTP/SSE | WebSocket |
 | **Pluggability** | Event bus, KV store, object store | Unknown |
-| **License** | ISC (open) | Unknown |
+| **License** | MIT (open) | Unknown |
 | **Integration** | Native to NuSy architecture | External dependency |
-| **Maintenance** | Congruent Systems PBC | OpenClaw project |
+| **Maintenance** | Congruent Systems LLC | OpenClaw project |
 
 **Verdict:** Noesis Ship is purpose-built for multi-agent coordination with NuSy beings. OpenClaw is a generic bridge. Switching to Noesis Ship gives us:
 - Unified architecture (same as nusy-product-team)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "test:relay": "npm test --workspace=@noesis-ship/relay",
     "test:chat": "npm test --workspace=@noesis-ship/chat"
   },
-  "author": "Congruent Systems PBC",
-  "license": "ISC"
+  "author": "Congruent Systems LLC",
+  "license": "MIT"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ name = "noesis-ship"
 version = "0.2.0"
 description = "Pluggable multi-agent communication platform — NATS core with WebSocket, MCP, and HTTP/SSE adapters"
 readme = "README.md"
-license = "ISC"
+license = "MIT"
 requires-python = ">=3.11"
 authors = [
-    { name = "Congruent Systems PBC" },
+    { name = "Congruent Systems LLC" },
 ]
 keywords = ["nats", "multi-agent", "communication", "websocket", "mcp"]
 classifiers = [


### PR DESCRIPTION
Captain legal ruling (2026-07-01): the entity is officially **Congruent Systems LLC** (not PBC). Also aligns license metadata to the authoritative MIT `LICENSE` file (was inconsistently ISC in package.json / pyproject.toml / README).

**Changes** (doc/metadata only, no code):
- PBC → LLC: README, package.json, pyproject.toml, CLAUDE.md, docs/architecture-review-dgx.md
- ISC → MIT: package.json `license`, pyproject.toml `license`, README + CLAUDE.md License sections, architecture-review table
- Left untouched: third-party ISC entries in package-lock.json (correct — those are dependencies' own licenses)

Closes #26. Internal: CH-5436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)