### PR TITLE
fix(ci): drop archived fleet-log-writer.js from syntax check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
           node --check packages/relay/groups.js
           node --check packages/daemon/agent-daemon.js
           node --check packages/mcp-server/mcp-server.js
-          node --check packages/fleet-log/fleet-log-writer.js
           node --check packages/shared/index.js
           node --check packages/shared/config.js
           node --check packages/shared/nats-helpers.js


### PR DESCRIPTION
Removes the one stale `node --check` line pointing at the archived `packages/fleet-log/fleet-log-writer.js` (archived in 1bfa56c). That missing file was reddening main with MODULE_NOT_FOUND. All other checked files verified to exist. Closes #28. Internal: CH-5442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)